### PR TITLE
Fixed "New-ServiceNowTableEntry" to support UTF8 chars +  Added  "CustomFields" param to New-ServiceNowIncident

### DIFF
--- a/PSServiceNow-Incidents.psm1
+++ b/PSServiceNow-Incidents.psm1
@@ -167,6 +167,13 @@ function New-ServiceNowIncident{
         [parameter(ParameterSetName='SetGlobalAuth')]
         [string]$ConfigurationItem,
 
+        # custom fields as hashtable 
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [hashtable]$CustomFields,
+
         # Credential used to authenticate to ServiceNow  
         [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
         [ValidateNotNullOrEmpty()]
@@ -198,6 +205,10 @@ function New-ServiceNowIncident{
         'cmdb_ci' = $ConfigurationItem
     }
     
+    if($CustomFields)
+    {
+        $Values += $CustomFields 
+    }
     
     if ($Connection -ne $null)
     {

--- a/PSServiceNow-Tables.psm1
+++ b/PSServiceNow-Tables.psm1
@@ -145,9 +145,12 @@ function New-ServiceNowTableEntry{
     
     $Body = $Values | ConvertTo-Json;
 
+    #Convert to UTF8 array to support special chars such as the danish "æ","ø","å"
+    $utf8Bytes = [System.Text.Encoding]::UTf8.GetBytes($Body)
+
     # Fire and return
     $Uri = $ServiceNowURL + "/table/$Table"
-    return (Invoke-RestMethod -Uri $uri -Method Post -Credential $ServiceNowCredential -Body $Body -ContentType "application/json" -UseBasicParsing).result
+    return (Invoke-RestMethod -Uri $uri -Method Post -Credential $ServiceNowCredential -Body $utf8Bytes -ContentType "application/json" -UseBasicParsing).result
 }
 
 <#

--- a/PSServiceNow.psd1
+++ b/PSServiceNow.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.3'
+ModuleVersion = '0.1.4'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'


### PR DESCRIPTION
Fixed "New-ServiceNowTableEntry" to support UTF8 chars such as danish
"æ","ø","å"
Added  "CustomFields" param to New-ServiceNowIncident to be able to
support any fields in incident
