### PR TITLE
Edited Get-ServiceNowTable so it doesn't return $Body

### DIFF
--- a/PSServiceNow-Tables.psm1
+++ b/PSServiceNow-Tables.psm1
@@ -75,8 +75,6 @@ function Get-ServiceNowTable
         $Body.sysparm_query = $Query
     }
     
-    $Body
-
     # Fire and return
     $Uri = $ServiceNowURL + "/table/$Table"
 
@@ -145,7 +143,7 @@ function New-ServiceNowTableEntry{
     
     $Body = $Values | ConvertTo-Json;
 
-    #Convert to UTF8 array to support special chars such as the danish "æ","ø","å"
+    #Convert to UTF8 array to support special chars such as the danish "ï¿½","ï¿½","ï¿½"
     $utf8Bytes = [System.Text.Encoding]::UTf8.GetBytes($Body)
 
     # Fire and return

--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,12 @@ Set-ServiceNowAuth
 Get-ServiceNowIncident -MatchContains @{short_description='PowerShell'} 
 ```
 
+### Example - Retrieving an Incident Containing the Word 'PowerShell' with Automation
+```
+Import-Module PSServiceNow
+Get-ServiceNowIncident -MatchContains @{short_description='PowerShell'} -ServiceNowCredential $PSCredential -ServiceNowURL $ServiceNowURL
+```
+
 ## Cmdlets  
 * Get-ServiceNowChangeRequest
 * Get-ServiceNowConfigurationItem


### PR DESCRIPTION
Cmdlets that utilized Get-ServiceNowTable would return the value of
$Body as the first record.  Removed the line causing its entry.